### PR TITLE
Handle linux reporting aarch64 architecture

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,7 +34,7 @@ get_arch() {
     amd64 | x86_64)
       echo "x64"
       ;;
-    arm64)
+    arm64 | aarch64)
       echo "arm64"
       ;;
     armv7)


### PR DESCRIPTION
This change should resolve issues, at least on my machine, using this plugin to download tailwindcss. `uname -m` reports `aarch64` and that should result in downloading the arm64 binary - but rather the arch is unrecognized so we get empty string.